### PR TITLE
Update React Dependency for Vercel Compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "next": "14.2.3",
-    "react": "18.3.0",
-    "react-dom": "18.3.0"
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",
@@ -22,5 +22,8 @@
     "eslint-config-next": "^14.2.3",
     "@typescript-eslint/eslint-plugin": "^7.8.0",
     "@typescript-eslint/parser": "^7.8.0"
+  },
+  "engines": {
+    "node": ">=18.17 <21"
   }
 }


### PR DESCRIPTION
This pull request modifies the `package.json` to downgrade the `react` and `react-dom` dependencies from version `18.3.0` to `18.2.0`, which resolves compatibility issues with Vercel. Additionally, I have added an `engines` section to specify the supported Node.js version range. This should help ensure smoother deployments on the Vercel platform.

---

> This pull request was co-created with Cosine Genie

Original Task: [uybc-boats/ywqqpncqosex](https://cosine.sh/k2f6okl6y3fg/uybc-boats/task/ywqqpncqosex)
Author: benjwalker226
