### PR TITLE
Fix vercel.json schema validation issue

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "outputDirectory": ".next",
-  "nodeVersion": "20.x"
+  "outputDirectory": ".next"
 }


### PR DESCRIPTION
This pull request removes the `nodeVersion` property from the `vercel.json` configuration file, which was causing schema validation errors. The updated configuration is now compliant with the expected schema, ensuring that deployments on Vercel proceed without issues.

---

> This pull request was co-created with Cosine Genie

Original Task: [uybc-boats/y9rlcjrcp14w](https://cosine.sh/k2f6okl6y3fg/uybc-boats/task/y9rlcjrcp14w)
Author: benjwalker226
