### PR TITLE
Fix logo display issue in Layout component

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from "react";
 import Head from "next/head";
 import Image from "next/image";
+import LogoImg from "../public/logo.png";
 
 interface LayoutProps {
   children: ReactNode;
@@ -13,12 +14,11 @@ const Layout = ({ children }: LayoutProps) => (
     </Head>
     <header className="logo-header">
       <Image
-        src="/logo.png"
+        src={LogoImg}
         alt="Logo"
         width={120}
         height={120}
         priority
-        unoptimized
       />
     </header>
     {children}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,9 +4,6 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
-  images: {
-    unoptimized: true,
-  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
This pull request modifies the `Layout` component to correctly display the logo image when hosted on Vercel. The logo was previously not showing up due to incorrect image sourcing. The changes include importing the logo image directly from the `public` directory using `next/image`. Additionally, I removed the unoptimized image settings from `next.config.mjs`, which were not needed as they were conflicting with the image optimization features of Next.js.

---

> This pull request was co-created with Cosine Genie

Original Task: [uybc-boats/jsq2sjij6mle](https://cosine.sh/k2f6okl6y3fg/uybc-boats/task/jsq2sjij6mle)
Author: benjwalker226
