### PR TITLE
Move Logo to Center Above Title and Update Button Styles

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -16,16 +16,6 @@ const Layout = ({ children }: LayoutProps) => (
       {/* fallback/default */}
       <link rel="icon" href="/logo/logo.png" type="image/png" sizes="64x64 32x32 16x16" />
     </Head>
-    <header className="logo-header">
-      <Image
-        src="/logo/logo.png"
-        alt="Logo"
-        width={200}
-        height={200}
-        priority
-        className="site-logo"
-      />
-    </header>
     {children}
   </div>
 );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import Head from "next/head";
 import Link from "next/link";
+import Image from "next/image";
 
 export default function Home() {
   return (
@@ -8,6 +9,17 @@ export default function Home() {
         <title>UYBC Boat Managament</title>
       </Head>
       <main className="main-center-container" style={{ minHeight: "70vh", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
+        {/* Logo centered above the title */}
+        <div className="logo-header">
+          <Image
+            src="/logo/logo.png"
+            alt="Logo"
+            width={200}
+            height={200}
+            priority
+            className="site-logo"
+          />
+        </div>
         <h1 style={{ fontSize: "2.4rem", marginBottom: "2rem", textAlign: "center" }}>UYBC Boat Managament</h1>
         <div style={{ display: "flex", gap: "2rem", flexWrap: "wrap", justifyContent: "center" }}>
           <Link href="/booking" passHref legacyBehavior>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -86,17 +86,21 @@ label {
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.18s, box-shadow 0.18s;
+  transition: background 0.18s, box-shadow 0.18s, transform 0.16s;
   margin-top: 0.25rem;
   margin-bottom: 1rem;
   display: inline-block;
   box-shadow: 0 0 0 rgba(0,0,0,0); /* transition baseline */
+  text-decoration: none; /* Remove underlining */
 }
 
 .button-primary:hover,
 .button-primary:focus {
   background: #0059c9;
   box-shadow: 0 2px 8px 0 rgba(0,112,243,0.10), 0 1.5px 4px 0 rgba(0,0,0,0.03);
+  text-decoration: none; /* Ensure no underline on hover/focus */
+  transform: translateY(-2px) scale(1.035);
+  filter: brightness(1.07);
 }
 
 .success-message {


### PR DESCRIPTION
This pull request moves the logo from the header to a centralized position directly above the title on the homepage. Additionally, it removes underlining from the text on the buttons and adds a hover effect that incorporates a slight scale transformation and brightness adjustment, enhancing the visual feedback for users.

---

> This pull request was co-created with Cosine Genie

Original Task: [uybc-boats/66xacki8dpwq](https://cosine.sh/k2f6okl6y3fg/uybc-boats/task/66xacki8dpwq)
Author: benjwalker226
