### PR TITLE
Fix spelling of 'Management' in titles

### DIFF
--- a/pages/booking.tsx
+++ b/pages/booking.tsx
@@ -32,7 +32,7 @@ export default function Booking() {
   return (
     <>
       <Head>
-        <title>Boat Damage/Repair Report | UYBC Boat Managament</title>
+        <title>Boat Damage/Repair Report | UYBC Boat Management</title>
       </Head>
       <main className="main-center-container">
         {!submitted ? (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -20,7 +20,7 @@ export default function Home() {
             className="site-logo"
           />
         </div>
-        <h1 style={{ fontSize: "2.4rem", marginBottom: "2rem", textAlign: "center" }}>UYBC Boat Managament</h1>
+        <h1 style={{ fontSize: "2.4rem", marginBottom: "2rem", textAlign: "center" }}>UYBC Boat Management</h1>
         <div style={{ display: "flex", gap: "2rem", flexWrap: "wrap", justifyContent: "center" }}>
           <Link href="/booking" passHref legacyBehavior>
             <a

--- a/pages/maintenance.tsx
+++ b/pages/maintenance.tsx
@@ -32,7 +32,7 @@ export default function Maintenance() {
   return (
     <>
       <Head>
-        <title>Equipment Request | UYBC Boat Managament</title>
+        <title>Equipment Request | UYBC Boat Management</title>
       </Head>
       <main className="main-center-container">
         {!submitted ? (


### PR DESCRIPTION
This pull request corrects the spelling of 'Management' from 'Managament' in the titles across the following pages: booking, index, and maintenance. The changes enhance the professionalism of our website's presentation.

---

> This pull request was co-created with Cosine Genie

Original Task: [uybc-boats/w39kmqen7enf](https://cosine.sh/k2f6okl6y3fg/uybc-boats/task/w39kmqen7enf)
Author: benjwalker226
