### PR TITLE
Remove 'All rights reserved' from footer

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -20,7 +20,7 @@ const Layout = ({ children }: LayoutProps) => (
     </Head>
     {children}
     <footer style={{ textAlign: "center", marginTop: "2rem", padding: "1rem 0", color: "#888", fontSize: "0.95rem" }}>
-      &copy; {new Date().getFullYear()} Ben Walker. All rights reserved.
+      &copy; {new Date().getFullYear()} Ben Walker.
     </footer>
   </div>
 );


### PR DESCRIPTION
This PR updates the footer in the Layout component to remove the 'All rights reserved' text while retaining the copyright notice. This change simplifies the footer without losing the identification of the copyright owner.

---

> This pull request was co-created with Cosine Genie

Original Task: [uybc-boats/m9hwt8murqs8](https://cosine.sh/k2f6okl6y3fg/uybc-boats/task/m9hwt8murqs8)
Author: benjwalker226
