### PR TITLE
Increase logo size for better mobile responsiveness

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -153,8 +153,8 @@ label {
 
 /* New, more specific styling for enlarged responsive logo */
 .site-logo {
-  /* Responsive scaling: min 240px, prefers 28vw, max 480px */
-  max-width: clamp(240px, 28vw, 480px);
+  /* Responsive scaling: min 140px, prefers 40vw, max 360px */
+  max-width: clamp(140px, 40vw, 360px);
   width: 100%;
   height: auto;
   display: block;
@@ -163,7 +163,8 @@ label {
 /* Responsive adjustment for narrow screens */
 @media (max-width: 500px) {
   .site-logo {
-    max-width: 200px;
+    max-width: 80vw;
+    min-width: 140px;
   }
 }
 


### PR DESCRIPTION
This pull request addresses the issue of a logo being too small on mobile devices. The styling for the `.site-logo` class has been updated in `styles/globals.css` to improve the responsive scaling. The logo's minimum size is now set to 140px, prefers 40vw, and is capped at 360px, making it more appropriate for different screen sizes. Additionally, for screens narrower than 500px, the logo can now occupy 80vw, with a minimum width of 140px, ensuring better visibility on mobile devices.

---

> This pull request was co-created with Cosine Genie

Original Task: [uybc-boats/s7sloem1mt1w](https://cosine.sh/k2f6okl6y3fg/uybc-boats/task/s7sloem1mt1w)
Author: benjwalker226
