### PR TITLE
Adjust button spacing on mobile for improved layout

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -23,7 +23,7 @@ export default function Home() {
           />
         </div>
         <h1 style={{ fontSize: "2.4rem", marginBottom: "2rem", textAlign: "center" }}>UYBC Boat Management</h1>
-        <div style={{ display: "flex", gap: "2rem", flexWrap: "wrap", justifyContent: "center" }}>
+        <div className="button-group">
           <a
             href="https://docs.google.com/forms/d/e/1FAIpQLSc2jc31Qzd3DL5zLmYHnT7td6JchvFHFurqVWzwqgt4XQQ9OA/viewform?usp=dialog"
             className="button-primary"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -56,7 +56,22 @@ html, body {
     margin: 0 0.5rem;
   }
   /* Primary buttons go full width and scale font on mobile */
-  .button-primary {
+.button-primary {
+
+}
+
+/* Button group spacing for index page */
+.button-group {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+@media (max-width: 600px) {
+  .button-group {
+    gap: 0.75rem;
+  }
+}
     width: 100%;
     min-width: auto;
     font-size: 1.05rem;


### PR DESCRIPTION
This pull request modifies the layout of buttons on the mobile view by adjusting their spacing. The buttons are now grouped with a reduced gap of 0.75rem specifically for screens smaller than 600px, which enhances the visual flow and accessibility on mobile devices. Changes were made in `pages/index.tsx` to structure the button group and in `styles/globals.css` to control the spacing responsively.

---

> This pull request was co-created with Cosine Genie

Original Task: [uybc-boats/qjwjzwojnml4](https://cosine.sh/k2f6okl6y3fg/uybc-boats/task/qjwjzwojnml4)
Author: benjwalker226
